### PR TITLE
Let the NodeType of root be a sub-class of Window or Application

### DIFF
--- a/src/FsXaml.Wpf.TypeProvider/XamlTypeProvider.fs
+++ b/src/FsXaml.Wpf.TypeProvider/XamlTypeProvider.fs
@@ -278,10 +278,10 @@ type public XamlTypeProvider(config : TypeProviderConfig) as this =
                         outertype.AddMember ctor
                         outertype
                     match root.NodeType with
-                    | win when win = typeof<System.Windows.Window> ->
-                        createFactoryType typeof<XamlTypeFactory<System.Windows.Window>>
-                    | app when app = typeof<System.Windows.Application> ->
-                        createFactoryType(typeof<XamlTypeFactory<System.Windows.Application>>)
+                    | win when typeof<System.Windows.Window>.IsAssignableFrom win ->
+                        createFactoryType (typedefof<XamlTypeFactory<_>>.MakeGenericType(win))
+                    | app when typeof<System.Windows.Application>.IsAssignableFrom app ->
+                        createFactoryType (typedefof<XamlTypeFactory<_>>.MakeGenericType(app))
                     | rd when rd = typeof<System.Windows.ResourceDictionary> ->
                         createFactoryType(typeof<XamlTypeFactory<System.Windows.ResourceDictionary>>)
                     | _ ->


### PR DESCRIPTION
I made some minor changes so that the root node of the XAML file can be a sub-class of Window or Application. (The existing code failed when I used XAML with a root node of the MetroWindow class from the MahApps.Metro Nuget package)
