### PR TITLE
Inverted val and removed type alias

### DIFF
--- a/demos/WpfMvvmAgent/MainViewModel.fs
+++ b/demos/WpfMvvmAgent/MainViewModel.fs
@@ -15,37 +15,35 @@ type Point  =
     { X: float; Y: float }
     override x.ToString() = sprintf "(%.1f : %.1f)" x.X x.Y
  
-type Agent<'T> = MailboxProcessor<'T>
- 
 type MainViewModel() as me = 
     inherit ViewModelBase()
 
     let ui = SynchronizationContext.Current
 
-    let trackPositions = me.Factory.Backing(<@ me.TrackPositions @>, false)
+    let trackPositions = me.Factory.Backing(<@ me.TrackPositions @>, true)
     let positions = ObservableCollection<Point>()
     let maxPositions = 20
  
-    let agent = Agent.Start(fun inbox ->
+    let agent = MailboxProcessor.Start(fun inbox ->
                async {
                     while true do
                         let! pt = inbox.Receive()
-                        
-                        if not(me.TrackPositions) then
+
+                        if me.TrackPositions then
                             // Update our UI
                             do! Async.SwitchToContext ui
                             if positions.Count > maxPositions then positions.RemoveAt 0
                             positions.Add(pt)
                })
 
-    let clear ui = async { 
-            me.TrackPositions <- true            
+    let clear ui = async {
+            me.TrackPositions <- false
             while positions.Count > 0 do
                 do! Async.Sleep 100
                 do! Async.SwitchToContext ui
                 positions.RemoveAt(positions.Count - 1)
             
-            me.TrackPositions <- false
+            me.TrackPositions <- true
         }
 
     let clearCommand = me.Factory.CommandAsync(clear)


### PR DESCRIPTION
I inverted TrackPositions to mean what its value is; so when set to true, we are tracking positions; false, we are not.  It seems this might be the intention of the variable name as WindowsStoreVM was about to use it in this manner too.  

(First GitHub commit; learning F#)
