### PR TITLE
Provided a more detailed exception message when .xaml files aren't set to Resource

### DIFF
--- a/src/FsXaml.Wpf/Utilities.fs
+++ b/src/FsXaml.Wpf/Utilities.fs
@@ -19,18 +19,3 @@ module internal Utilities =
         {new IEventArgsConverter with
             member this.Convert (args : EventArgs) param =
                 args :> obj }
-
-        // The intent of this function was to be able to pass a line number and line position
-        // to this function and it would return the property name and property value at that 
-        // position, given the stream.
-        // let internal getXMLObjectAt (ms : MemoryStream) (lineNum : int) (linePos : int) =
-//        use streamReader = new StreamReader(ms)
-//        streamReader.BaseStream.Position <- 0L
-//        for i = 1 to lineNum - 1 do
-//            streamReader.ReadLine() |> ignore
-//        for i = 1 to linePos - 1 do
-//            streamReader.Read() |> ignore
-          //TODO: Use regex here instead
-//        let xmlProp = streamReader.ReadLine().Split(' ').[0]
-//        let xmlVal = xmlProp.Split('"').[1]
-//        ( xmlProp, xmlVal ) 

--- a/src/FsXaml.Wpf/Wpf-XamlUtilities.fs
+++ b/src/FsXaml.Wpf/Wpf-XamlUtilities.fs
@@ -29,11 +29,7 @@ module LoadXaml =
             try
                 System.Windows.Markup.XamlReader.Load(ms) |> unbox
             with
-                | :? System.Windows.Markup.XamlParseException as ioe -> 
-                    // TODO: Replace Contains with line number & position function to display
-                    //       XAML property and property value causing the issue.
-                    match ioe.Message.Contains("The invocation of the constructor on type") with
-                        | true -> failwith "Unable to load XAML data. Verify that all .xaml files are compiled as \"Resources\""
-                        | false -> reraise()    
+                | ioe when ioe.Message.Contains("The invocation of the constructor on type") ->
+                    failwith "Unable to load XAML data. Verify that all .xaml files are compiled as \"Resource\""
                 | _ -> reraise()
                         


### PR DESCRIPTION
This should close issue #8.  

In addition, I have also found that if some .xaml files are set to resource and some aren't--i.e. App.xaml is Resource and MainWindow.xaml is set to Content--PresentationFramework will throw the file name of the .xaml file causing issues and the code I added (handling for XamlParseException) will remind user to set all .xaml files to resource.  

I plan to write an utility function that will find the exact property and property value causing issues for when an exception message provides a line number and column position of where the stream was when the exception occurred.
