### PR TITLE
Update module references for FSharp.ViewModule.Core

### DIFF
--- a/demos/WpfMvvmAgent/WpfMvvmAgent.fsproj
+++ b/demos/WpfMvvmAgent/WpfMvvmAgent.fsproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FSharp.ViewModule">
-      <HintPath>..\..\packages\FSharp.ViewModule.Core.0.9.9.2\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.ViewModule.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.ViewModule.Core.0.9.9.3\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.ViewModule.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FsXaml.Wpf">

--- a/demos/WpfSimpleDrawingApplication/WpfSimpleDrawingApplication.fsproj
+++ b/demos/WpfSimpleDrawingApplication/WpfSimpleDrawingApplication.fsproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FSharp.ViewModule">
-      <HintPath>..\..\packages\FSharp.ViewModule.Core.0.9.9.2\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.ViewModule.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.ViewModule.Core.0.9.9.3\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.ViewModule.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FsXaml.Wpf">

--- a/demos/WpfSimpleMvvmApplication/WpfSimpleMvvmApplication.fsproj
+++ b/demos/WpfSimpleMvvmApplication/WpfSimpleMvvmApplication.fsproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FSharp.ViewModule">
-      <HintPath>..\..\packages\FSharp.ViewModule.Core.0.9.9.2\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.ViewModule.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.ViewModule.Core.0.9.9.3\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.ViewModule.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FsXaml.Wpf">


### PR DESCRIPTION
I tried to open `FsXamlDemos.sln` after running build.cmd, and three of the example projects failed to build (could not find FSharp.ViewModule). The reason is that the references to `FSharp.ViewModule` in the example fsproj files refer to `FSharp.ViewModule.Core.0.9.9.2` instead of the correct version 0.9.9.3. 
