### PR TITLE
HandlerExtension + demo WIP.

### DIFF
--- a/FsXaml.Demos.sln
+++ b/FsXaml.Demos.sln
@@ -18,6 +18,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpDesktopUINumericUpDow
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FsharpAttachedProperty", "demos\FsharpAttachedProperty\FsharpAttachedProperty.fsproj", "{7D568A2D-1014-437C-879C-05E3D5F3A515}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "WpfSimpleDrawingApplication2", "demos\WpfSimpleDrawingApplication2\WpfSimpleDrawingApplication2.fsproj", "{6A3A3470-CA82-4139-846B-0670144D8D1A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/demos/WpfSimpleDrawingApplication2/App.config
+++ b/demos/WpfSimpleDrawingApplication2/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/demos/WpfSimpleDrawingApplication2/App.xaml
+++ b/demos/WpfSimpleDrawingApplication2/App.xaml
@@ -1,0 +1,8 @@
+﻿<Application
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"    
+    StartupUri="MainWindow.xaml"
+  >
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/demos/WpfSimpleDrawingApplication2/CoreTypes.fs
+++ b/demos/WpfSimpleDrawingApplication2/CoreTypes.fs
@@ -1,0 +1,14 @@
+﻿namespace WpfSimpleDrawingApplication2
+
+open System
+
+type Point = { X: float; Y: float }
+type PointPair = { Start : Point; End : Point }
+
+type RelayObserver<'t>(onNext) =
+    let onNext = onNext
+    interface IObserver<'t> with
+        member __.OnNext value = onNext value
+        member __.OnError error = ()
+        member __.OnCompleted() = ()
+

--- a/demos/WpfSimpleDrawingApplication2/MainViewModel.fs
+++ b/demos/WpfSimpleDrawingApplication2/MainViewModel.fs
@@ -1,0 +1,19 @@
+﻿namespace WpfSimpleDrawingApplication2
+
+open System
+open System.Collections.ObjectModel
+
+type MainViewModel() =
+    let lines = ObservableCollection<PointPair>()
+    let mutable previous = None
+    let handleMove p = 
+        match previous with 
+        | Some p1 -> lines.Add({ Start = p1; End = p } )
+        | _ -> ()
+        previous <- Some p
+
+    let onMouseMove = RelayObserver handleMove
+    
+    member this.OnMouseMove = onMouseMove
+    // Our lines for visual binding
+    member __.Lines = lines    

--- a/demos/WpfSimpleDrawingApplication2/MainWindow.xaml
+++ b/demos/WpfSimpleDrawingApplication2/MainWindow.xaml
@@ -1,0 +1,49 @@
+﻿<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:fsxaml="http://github.com/fsprojects/FsXaml"
+        xmlns:local="clr-namespace:WpfSimpleDrawingApplication2;assembly=WpfSimpleDrawingApplication2"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        Title="Drawing using EventToFSharpEvent">
+    <Window.DataContext>
+        <local:MainViewModel />
+    </Window.DataContext>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0"
+                   HorizontalAlignment="Center"
+                   FontSize="14"
+                   Text="draw with the mouse anywhere in the region below" />
+        <Border Grid.Row="1"
+                BorderBrush="Black"
+                BorderThickness="1"
+                ClipToBounds="True">
+            <ItemsControl HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch"
+                          Background="Transparent"
+                          ItemsSource="{Binding Path=Lines}"
+                          MouseMove="{fsxaml:Handler {Binding OnMouseMove},
+                                                     {x:Static local:Map.MouseEventArgsToPoint}}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <Canvas HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                Background="White" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Line Stroke="Black"
+                              StrokeThickness="1"
+                              X1="{Binding Start.X}"
+                              X2="{Binding End.X}"
+                              Y1="{Binding Start.Y}"
+                              Y2="{Binding End.Y}" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </Border>
+    </Grid>
+</Window>

--- a/demos/WpfSimpleDrawingApplication2/MainWindow.xaml.fs
+++ b/demos/WpfSimpleDrawingApplication2/MainWindow.xaml.fs
@@ -1,0 +1,11 @@
+﻿namespace WpfSimpleDrawingApplication2
+
+open System
+open System.Collections.ObjectModel
+open System.ComponentModel
+
+open FsXaml
+
+type MainWindow = XAML<"MainWindow.xaml">
+
+

--- a/demos/WpfSimpleDrawingApplication2/Map.fs
+++ b/demos/WpfSimpleDrawingApplication2/Map.fs
@@ -1,0 +1,17 @@
+﻿namespace WpfSimpleDrawingApplication2
+
+open System
+open System.Windows
+open System.Windows.Controls
+open System.Windows.Input
+open System.Windows.Markup
+open FsXaml
+
+// This would typically be defined in a separate project/namespace along with the XAML, as it's "pure view layer" logic
+// Converters are used to map from View events -> our F# defined types in the ViewModel or Model layer
+module Map =
+    let mouseEventArgsToPoint (args : MouseEventArgs) =
+        let source = args.OriginalSource :?> IInputElement
+        let pt = args.GetPosition(source)
+        { X = pt.X; Y = pt.Y }
+    let MouseEventArgsToPoint = mouseEventArgsToPoint

--- a/demos/WpfSimpleDrawingApplication2/Program.fs
+++ b/demos/WpfSimpleDrawingApplication2/Program.fs
@@ -1,0 +1,9 @@
+﻿open System
+open FsXaml
+
+type App = XAML<"App.xaml">
+
+[<STAThread>]
+[<EntryPoint>]
+let main _ = 
+    App().Run ()

--- a/demos/WpfSimpleDrawingApplication2/WpfSimpleDrawingApplication2.fsproj
+++ b/demos/WpfSimpleDrawingApplication2/WpfSimpleDrawingApplication2.fsproj
@@ -1,0 +1,102 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{6a3a3470-ca82-4139-846b-0670144d8d1a}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>WpfSimpleDrawingApplication2</RootNamespace>
+    <AssemblyName>WpfSimpleDrawingApplication2</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <Name>WpfSimpleDrawingApplication2</Name>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\WpfSimpleDrawingApplication2.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\WpfSimpleDrawingApplication2.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FsXaml.Wpf">
+      <HintPath>..\..\bin\FsXaml.Wpf\FsXaml.Wpf.dll</HintPath>
+    </Reference>
+    <Reference Include="FsXaml.Wpf.TypeProvider">
+      <HintPath>..\..\bin\FsXaml.Wpf.TypeProvider\FsXaml.Wpf.TypeProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Windows" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CoreTypes.fs" />
+    <Compile Include="Map.fs" />
+    <Compile Include="MainViewModel.fs" />
+    <Resource Include="App.xaml" />
+    <Resource Include="MainWindow.xaml" />
+    <Compile Include="MainWindow.xaml.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+    <None Include="paket.references" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Import Project="..\..\.paket\paket.targets" />
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')" />
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')" />
+  </Choose>
+</Project>

--- a/src/FsXaml.Wpf/FsXaml.Wpf.fsproj
+++ b/src/FsXaml.Wpf/FsXaml.Wpf.fsproj
@@ -60,6 +60,7 @@
     <Compile Include="Utilities.fs" />
     <Compile Include="ValueConverters.fs" />
     <Compile Include="AttachedProperties.fs" />
+    <Compile Include="MarkupExtensions.fs" />
     <Compile Include="WpfXmlnsDefinitions.fs" />
     <Compile Include="AssemblyInfo.fs" />
   </ItemGroup>

--- a/src/FsXaml.Wpf/MarkupExtensions.fs
+++ b/src/FsXaml.Wpf/MarkupExtensions.fs
@@ -1,0 +1,83 @@
+﻿namespace FsXaml
+
+open System
+open System.Windows
+open System.Windows.Data
+open System.Windows.Input
+open System.Windows.Markup
+
+module ServiceProvider = 
+    let private getService<'t> (serviceProvider : IServiceProvider) = serviceProvider.GetService typeof<'t> :?> 't
+    let ProvideValueTarget serviceProvider = getService<IProvideValueTarget> serviceProvider
+
+module Reflection = 
+    let tryGetMethod (t: Type) methodName =
+        let tryGetMethod (t: Type) methodName =
+            let mi = t.GetMethod methodName
+            if obj.ReferenceEquals(mi, null) then None
+            else Some(mi)
+        t.GetInterfaces()
+        |> Array.tryPick (fun i -> tryGetMethod i methodName)
+
+    let private tryGetAnyMethod source methodName =
+        let t = source.GetType()
+        let mi = t.GetMethod methodName
+        if obj.ReferenceEquals(mi, null) then
+            tryGetMethod t methodName
+        else Some(mi)
+
+    let invoke source methodName arg = 
+        let mi = tryGetAnyMethod source methodName
+        match mi with
+        | Some mi -> mi.Invoke(source, [| arg |])
+        | None -> failwithf "Could not find method: %s"  methodName
+
+type ToArrayConverter() = 
+    static member Default = ToArrayConverter()
+    interface IMultiValueConverter with
+        member x.Convert(values : obj [], _, _, _) : obj = 
+            // clone is needed here, if we return the same instance WPF ~fixes~ it by replaing it with an array of nulls.
+            values.Clone()
+        member x.ConvertBack(_, _, _, _) : obj [] = failwith "Not supported"
+
+[<MarkupExtensionReturnType(typeof<RoutedEventHandler>)>]
+type HandlerExtension(observerBinding : Binding, map : obj) as me = 
+    inherit MarkupExtension()
+    let observerBinding = observerBinding
+    let map = map
+    static let HandlersProperty = 
+        DependencyProperty.RegisterAttached
+            ("Handlers", typeof<ResizeArray<HandlerExtension>>, typeof<HandlerExtension>, PropertyMetadata(null))
+    static let ObserversProperty = 
+        DependencyProperty.RegisterAttached
+            ("Observers", typeof<obj []>, typeof<HandlerExtension>, PropertyMetadata(null))
+    
+    let bindObserver (element : FrameworkElement) = 
+        let mutable handlers = element.GetValue(HandlersProperty) :?> ResizeArray<HandlerExtension>
+        if obj.ReferenceEquals(handlers, null) then 
+            handlers <- ResizeArray<HandlerExtension>()
+            element.SetValue(HandlersProperty, handlers)
+        handlers.Add me
+        let binding = MultiBinding()
+        binding.Converter <- ToArrayConverter.Default
+        for handler in handlers do
+            binding.Bindings.Add handler.ObserverBinding
+        BindingOperations.SetBinding(element, ObserversProperty, binding)
+    
+    let getObserver (element : FrameworkElement) = 
+        let handlers = element.GetValue(HandlersProperty) :?> ResizeArray<HandlerExtension>
+        let index = handlers.IndexOf(me)
+        let observers = element.GetValue(ObserversProperty) :?> obj []
+        observers.[index]
+    
+    let onEvent (sender : obj) (e : RoutedEventArgs) = 
+        let mapped = Reflection.invoke map "Invoke" e
+        let observer = getObserver (sender :?> FrameworkElement)
+        Reflection.invoke observer "OnNext" mapped |> ignore
+    
+    override this.ProvideValue(serviceProvider : IServiceProvider) = 
+        let provideValueTarget = ServiceProvider.ProvideValueTarget serviceProvider
+        bindObserver (provideValueTarget.TargetObject :?> FrameworkElement) |> ignore
+        RoutedEventHandler onEvent :> _
+    
+    member __.ObserverBinding = observerBinding

--- a/tests/FsXaml.Tests/FsXaml.Tests.fsproj
+++ b/tests/FsXaml.Tests/FsXaml.Tests.fsproj
@@ -66,12 +66,15 @@
     <Compile Include="Tests.fs" />
     <None Include="paket.references" />
     <Content Include="App.config" />
+    <Compile Include="RefelectionTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />

--- a/tests/FsXaml.Tests/RefelectionTests.fs
+++ b/tests/FsXaml.Tests/RefelectionTests.fs
@@ -1,0 +1,20 @@
+﻿module FsXaml.RefelectionTests
+
+open System
+open FsXaml
+open NUnit.Framework
+
+type RelayObserver<'t>(onNext) = 
+    let onNext = onNext
+    interface IObserver<'t> with
+        member __.OnNext value = onNext value
+        member __.OnError error = ()
+        member __.OnCompleted() = ()
+
+[<Test>]
+let ``invoke OnNext``() = 
+    let mutable sum = 0
+    let increment i = sum <- sum + i
+    let observer = RelayObserver(increment)
+    Reflection.invoke observer "OnNext" 2 |> ignore
+    Assert.AreEqual(2, sum)


### PR DESCRIPTION
- Proof-of-concept implementation for discussion.
- No optimization in the reflection.
- No filtering, draws constantly.

# Questions
- How do we want names and xaml syntax? As it is written now there is only one constructor forcing us to pass in a mapper.
- I'm thinking maybe the mapper should get sender, eventargs and the observer passed in. This would enable:
  - Passing in the observer would enable filtering in the mapper.
  - Rx style eventpattern with both sender and args.