### PR TITLE
Wrapped an obscure XAML writing exception during XAML injection into …

### DIFF
--- a/src/FsXaml.Wpf/Utilities.fs
+++ b/src/FsXaml.Wpf/Utilities.fs
@@ -50,8 +50,13 @@ module InjectXaml =
             use writer = new XamlObjectWriter(reader.SchemaContext, writerSettings)
 
             while reader.Read() do
-                writer.WriteNode(reader)
-
+                try
+                    writer.WriteNode(reader)
+                with 
+                | :? XamlObjectWriterException as xowe 
+                    -> let msg = (file, reader.LineNumber, reader.LinePosition) 
+                                 |||> sprintf "XamlObjectWriterException caught writing XAML from %s. Reader at line %d, position %d." 
+                       raise (new Exception( msg, xowe ))
             writer.Result
             |> ignore
 


### PR DESCRIPTION
…a standard Exception with a message indicating the location of the offending XAML in the file. The idea is that this will at least point the user to the problem source rather than leave them confused by an incomprehensible message. To see an example of said incomprehensible message, try having a <CheckBox> with a "Checked={Binding ...}" attribute (instead of the correct "IsChecked=...") in your XAML.