### PR TITLE
Adds support for use from FSI

### DIFF
--- a/FsXaml.Demos.sln
+++ b/FsXaml.Demos.sln
@@ -21,6 +21,11 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FsharpAttachedProperty", "d
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "WpfSimpleDrawingApplication2", "demos\WpfSimpleDrawingApplication2\WpfSimpleDrawingApplication2.fsproj", "{6A3A3470-CA82-4139-846B-0670144D8D1A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9259ABCB-C72D-476D-BBD0-DD5455520856}"
+	ProjectSection(SolutionItems) = preProject
+		demos\FsXamlInteractive.fsx = demos\FsXamlInteractive.fsx
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/demos/FsXamlInteractive.fsx
+++ b/demos/FsXamlInteractive.fsx
@@ -20,14 +20,13 @@ open Gjallarhorn
 
 Gjallarhorn.Wpf.Platform.install true |> ignore
 
-let [<Literal>] xamlFile = __SOURCE_DIRECTORY__ + "/FsXamlInteractiveWindow.xaml"
+let [<Literal>] XamlFile = __SOURCE_DIRECTORY__ + "/FsXamlInteractiveWindow.xaml"
 
-type MainWindow = XAML<xamlFile>
-
+type MainWindow = XAML<XamlFileLocation = XamlFile>
 
 let bindingSource = Binding.createSource ()
 
-bindingSource.ConstantToView ("XAML loaded from: " + xamlFile, "Title")
+bindingSource.ConstantToView ("XAML loaded from: " + XamlFile, "Title")
 
 bindingSource
 |> Binding.createCommand "ClickCommand"

--- a/demos/FsXamlInteractive.fsx
+++ b/demos/FsXamlInteractive.fsx
@@ -1,0 +1,42 @@
+﻿#r "presentationframework"
+#r "PresentationCore"
+#r "WindowsBase"
+#r "System.ObjectModel"
+#r "System.Xaml"
+
+#I __SOURCE_DIRECTORY__
+#r "../bin/fsxaml.wpf/fsxaml.wpf.dll"
+#r "../bin/fsxaml.wpf.typeprovider/fsxaml.wpf.typeprovider.dll"
+
+#r @"..\packages\Gjallarhorn\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\Gjallarhorn.dll"
+#r @"..\packages\Gjallarhorn.Bindable\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\Gjallarhorn.Bindable.dll"
+#r @"..\packages\Gjallarhorn.Bindable.Wpf\lib\net45\Gjallarhorn.Bindable.Wpf.dll"
+
+// Define your library scripting code here
+
+open FsXaml
+open Gjallarhorn.Bindable
+open Gjallarhorn
+
+Gjallarhorn.Wpf.Platform.install true |> ignore
+
+let [<Literal>] xamlFile = __SOURCE_DIRECTORY__ + "/FsXamlInteractiveWindow.xaml"
+
+type MainWindow = XAML<xamlFile>
+
+
+let bindingSource = Binding.createSource ()
+
+bindingSource.ConstantToView ("XAML loaded from: " + xamlFile, "Title")
+
+bindingSource
+|> Binding.createCommand "ClickCommand"
+|> Observable.map (fun _ -> 1)
+|> Observable.scan (+) 0
+|> Observable.map (sprintf "Clicks: %d")
+|> Signal.fromObservable "Click me"
+|> Binding.toView bindingSource "ButtonText"
+
+[1..2]
+|> List.iter (fun _ -> MainWindow(DataContext = bindingSource).ShowDialog() |> ignore)
+

--- a/demos/FsXamlInteractiveWindow.xaml
+++ b/demos/FsXamlInteractiveWindow.xaml
@@ -1,0 +1,12 @@
+﻿<Window
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:WpfApp1"
+        mc:Ignorable="d"
+        Title="{Binding Title}" Height="350" Width="600">
+    <Grid>
+        <Button Height="30" Width="100" Command="{Binding ClickCommand}" Content="{Binding ButtonText}"/>
+    </Grid>
+</Window>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,6 +5,7 @@ nuget FSharp.Core redirects: force
 nuget System.Windows.Interactivity.WPF 2.0.20525
 nuget FSharp.Desktop.UI 0.7.1
 nuget FSharp.ViewModule.Core 1.0.0.0
+nuget Gjallarhorn.Bindable.Wpf
 
 group Build
   source https://nuget.org/api/v2

--- a/paket.lock
+++ b/paket.lock
@@ -8,6 +8,12 @@ NUGET
       Rx-Main (>= 2.2.5)
     FSharp.ViewModule.Core (1.0)
       FSharp.Core
+    Gjallarhorn (0.0.9-beta)
+    Gjallarhorn.Bindable (0.0.9-beta)
+      Gjallarhorn (>= 0.0.9-beta)
+    Gjallarhorn.Bindable.Wpf (0.0.9-beta)
+      Gjallarhorn (>= 0.0.9-beta)
+      Gjallarhorn.Bindable (>= 0.0.9-beta)
     Rx-Core (2.2.5)
       Rx-Interfaces (>= 2.2.5)
     Rx-Interfaces (2.2.5)

--- a/src/FsXaml.Wpf.TypeProvider/XamlTypeUtils.fs
+++ b/src/FsXaml.Wpf.TypeProvider/XamlTypeUtils.fs
@@ -80,9 +80,9 @@ module internal XamlTypeUtils =
             
             providedType.AddMember handler     
                                
-    let createProvidedType assembly nameSpace typeName rootTypeInXaml resourcePath (initializeComponentMethod : ProvidedMethod) (initializedField : ProvidedField) xamlInfo =
+    let createProvidedType assembly nameSpace typeName rootTypeInXaml (path, loadFromResource) (initializeComponentMethod : ProvidedMethod) (initializedField : ProvidedField) xamlInfo =
         let providedType = ProvidedTypeDefinition(assembly, nameSpace, typeName, Some(rootTypeInXaml), IsErased = false)
-        providedType.AddXmlDoc (sprintf "%s defined in %s" rootTypeInXaml.Name resourcePath)
+        providedType.AddXmlDoc (sprintf "%s defined in %s" rootTypeInXaml.Name path)
                     
         // If our xamlInfo contains event handlers, we write the class as abstract
         let typeAttributes =
@@ -114,7 +114,7 @@ module internal XamlTypeUtils =
                     <@@
                         if (not (%%isInit : bool)) then
                             (%%setInit)                                            
-                            InjectXaml.from resourcePath (%%o : obj)                                            
+                            InjectXaml.from path loadFromResource (%%o : obj)                                            
                     @@>
                 | _ -> failwith "Wrong constructor arguments"
                                         

--- a/src/FsXaml.Wpf/Utilities.fs
+++ b/src/FsXaml.Wpf/Utilities.fs
@@ -59,20 +59,19 @@ module InjectXaml =
                 ms.Position <- 0L
                 ms
 
-    let from (file : string) (root : obj) =
+    let from (file : string) (loadFromResource : bool) (root : obj) =
         let s = System.IO.Packaging.PackUriHelper.UriSchemePack
         let t = root.GetType()
         
-        use ms = 
-            try
-                getResourceStream file t.Assembly :> Stream
-            with
-            | _ ->
+        use ms =
+            if loadFromResource then
                 try
-                    getEmbeddedResourceStream file t.Assembly :> _
+                    getResourceStream file t.Assembly :> Stream
                 with
                 | _ ->
-                    System.IO.File.OpenRead file :> _
+                    getEmbeddedResourceStream file t.Assembly :> _
+            else
+                System.IO.File.OpenRead file :> _
 
         use stream = new StreamReader(ms)
         use reader = new XamlXmlReader(stream, XamlReader.GetWpfSchemaContext())

--- a/src/FsXaml.Wpf/Utilities.fs
+++ b/src/FsXaml.Wpf/Utilities.fs
@@ -63,12 +63,16 @@ module InjectXaml =
         let s = System.IO.Packaging.PackUriHelper.UriSchemePack
         let t = root.GetType()
         
-        let ms = 
+        use ms = 
             try
-                getResourceStream file t.Assembly
+                getResourceStream file t.Assembly :> Stream
             with
-            | _ -> 
-                getEmbeddedResourceStream file t.Assembly
+            | _ ->
+                try
+                    getEmbeddedResourceStream file t.Assembly :> _
+                with
+                | _ ->
+                    System.IO.File.OpenRead file :> _
 
         use stream = new StreamReader(ms)
         use reader = new XamlXmlReader(stream, XamlReader.GetWpfSchemaContext())


### PR DESCRIPTION
This adds support for use from FSI, as suggested in #21.

I've added another static parameter to the type provider called `XamlFileLocation`, which can be specified as an alternative to the default `XamlResourceLocation`. When `XamlFileLocation` is specified, the XAML is loaded directly from the filesystem rather than from a resource.

An example script is included. The script displays a window twice, in order to demonstrate that closing the first window doesn't prevent the second from being displayed. (Note that if an instance of `System.Windows.Application` is created by the script, then only the first window will be displayed). 