### PR TITLE
Update Type Provider SDK to current master

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -52,9 +52,9 @@ GITHUB
     modules/Octokit/Octokit.fsx (51a7cae12acc7292db4623ae0e3cc3a2ce6ca1c9)
       Octokit (>= 0.20)
   remote: fsprojects/FSharp.TypeProviders.StarterPack
-    src/ProvidedTypes.fs (bebf76af3ffd2f9723b42de68d191f2371ecefd0)
-    src/ProvidedTypes.fsi (bebf76af3ffd2f9723b42de68d191f2371ecefd0)
-    src/ProvidedTypesTesting.fs (bebf76af3ffd2f9723b42de68d191f2371ecefd0)
+    src/ProvidedTypes.fs (1d9f236c03e749712b069c4fed51aec40a3c1601)
+    src/ProvidedTypes.fsi (1d9f236c03e749712b069c4fed51aec40a3c1601)
+    src/ProvidedTypesTesting.fs (1d9f236c03e749712b069c4fed51aec40a3c1601)
 GROUP Test
 RESTRICTION: >= net45
 NUGET

--- a/src/FsXaml.Wpf.TypeProvider/XamlTypeProvider.fs
+++ b/src/FsXaml.Wpf.TypeProvider/XamlTypeProvider.fs
@@ -91,8 +91,8 @@ type public XamlTypeProvider(config : TypeProviderConfig) as this =
                                     match args with 
                                     | [this] ->
                                         let o = Expr.Coerce(this, typeof<obj>)
-                                        let isInit = Expr.FieldGet(this, initializedField)
-                                        let setInit = Expr.FieldSet(this, initializedField, Expr.Value(true))
+                                        let isInit = Expr.FieldGet(Expr.Coerce(this, initializedField.DeclaringType), initializedField)
+                                        let setInit = Expr.FieldSet(Expr.Coerce(this, initializedField.DeclaringType), initializedField, Expr.Value(true))
                                         <@@
                                             if (not (%%isInit : bool)) then
                                                 (%%setInit)                                            

--- a/src/FsXaml.Wpf.TypeProvider/XamlTypeUtils.fs
+++ b/src/FsXaml.Wpf.TypeProvider/XamlTypeUtils.fs
@@ -98,7 +98,7 @@ module internal XamlTypeUtils =
                 invokeCode =
                     (fun args ->       
                         match args with
-                        | [this] -> Expr.Call(this, initializeComponentMethod, [ ])                                 
+                        | [this] -> Expr.Call(Expr.Coerce(this, initializeComponentMethod.DeclaringType), initializeComponentMethod, [ ])                                 
                         | _ -> failwith "Wrong constructor arguments"))
         providedConstructor.BaseConstructorCall <- fun args -> baseConstructorInfo, args                         
         providedType.AddMember providedConstructor


### PR DESCRIPTION
Making the change to the new SDK bits introduces design-time errors, throwing `System.ArgumentException` with `Incorrect instance type Parameter name: obj` (as mentioned in the commits). This pull request fixes this regression using `Expr.Coerce` based on personal experience working with recent versions of the Type Provider SDK.